### PR TITLE
Allow assets in updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Custom Expo Updates server
 
-This repo contains an server that implements the [Expo Updates protocol](https://github.com/expo/expo/pull/12461).
+This repo contains an server that implements the [Expo Updates protocol](https://docs.expo.dev/technical-specs/expo-updates-0).
 
 ## Why
 

--- a/common/helpers.js
+++ b/common/helpers.js
@@ -54,7 +54,8 @@ export function getAssetMetadataSync({
 
   return {
     hash: assetHash,
-    key: `${keyHash}.${keyExtensionSuffix}`,
+    key: keyHash,
+    fileExtension: `.${keyExtensionSuffix}`,
     contentType,
     url: `${process.env.HOSTNAME}/api/assets?asset=${assetFilePath}&runtimeVersion=${runtimeVersion}&platform=${platform}`,
   };

--- a/tests/manifest.test.js
+++ b/tests/manifest.test.js
@@ -7,27 +7,35 @@ import { parseItem } from 'structured-headers';
 import handleManifest from '../pages/api/manifest';
 
 function isManifestMultipartPart(multipartPart, part) {
-  const [, parameters] = parseItem(nullthrows(multipartPart.headers.get('content-disposition')));
+  const [, parameters] = parseItem(
+    nullthrows(multipartPart.headers.get('content-disposition'))
+  );
   const partName = parameters.get('name');
   return partName === part;
 }
 
 export async function getManifestPartAsync(response, part) {
   const multipartParts = await parseMultipartMixedResponseAsync(response);
-  const manifestPart = multipartParts.find(it => isManifestMultipartPart(it, part));
+  const manifestPart = multipartParts.find((it) =>
+    isManifestMultipartPart(it, part)
+  );
   return manifestPart;
 }
 
 async function parseMultipartMixedResponseAsync(res) {
   const contentType = res.getHeader('content-type');
   if (!contentType || typeof contentType != 'string') {
-    throw new Error('The multipart manifest response is missing the content-type header');
+    throw new Error(
+      'The multipart manifest response is missing the content-type header'
+    );
   }
 
   const boundaryRegex = /^multipart\/.+?; boundary=(?:"([^"]+)"|([^\s;]+))/i;
   const matches = boundaryRegex.exec(contentType);
   if (!matches) {
-    throw new Error('The content-type header in the HTTP response is not a multipart media type');
+    throw new Error(
+      'The content-type header in the HTTP response is not a multipart media type'
+    );
   }
   const boundary = matches[1] ?? matches[2];
 
@@ -119,7 +127,8 @@ test.each([
     'ios',
     {
       hash: '99b36e8b0afe02000087a91b220650e56106d1fa672bbc77f481aae9c21af3fb',
-      key: 'dacaa233e4886477facc9d5ca16952ad.bundle',
+      key: 'dacaa233e4886477facc9d5ca16952ad',
+      fileExtension: '.bundle',
       contentType: 'application/javascript',
       url: `${process.env.HOSTNAME}/api/assets?asset=updates/test/bundles/ios-dacaa233e4886477facc9d5ca16952ad.js&runtimeVersion=test&platform=ios`,
     },
@@ -128,7 +137,8 @@ test.each([
     'android',
     {
       hash: '3712b3a9c1e3bf7f383fe916a113d9937b5ec0ccfe5a5f4002b2ff8fb00fa681',
-      key: 'f1539de9a8bd655e7346639e6a6c2d2a.bundle',
+      key: 'f1539de9a8bd655e7346639e6a6c2d2a',
+      fileExtension: '.bundle',
       contentType: 'application/javascript',
       url: `${process.env.HOSTNAME}/api/assets?asset=updates/test/bundles/android-f1539de9a8bd655e7346639e6a6c2d2a.js&runtimeVersion=test&platform=android`,
     },
@@ -138,7 +148,8 @@ test.each([
 
   const firstAssetExpectation = {
     hash: 'cb65fafb5ed456fc3ed8a726cf4087d37b875184eba96f33f6d99104e6e2266d',
-    key: '489ea2f19fa850b65653ab445637a181.jpg',
+    key: '489ea2f19fa850b65653ab445637a181',
+    fileExtension: '.jpg',
     contentType: 'image/jpeg',
     url: `${process.env.HOSTNAME}/api/assets?asset=updates/test/assets/489ea2f19fa850b65653ab445637a181&runtimeVersion=test&platform=${platform}`,
   };
@@ -148,7 +159,7 @@ test.each([
       'expo-runtime-version': 'test',
       'expo-platform': platform,
       'expo-channel-name': 'main',
-      'expo-expect-signature': 'true'
+      'expo-expect-signature': 'true',
     },
   });
 


### PR DESCRIPTION
# Why

Fixes #3 

This PR updates the manifest response to be in line with the Expo Updates Protocol, as detailed here: https://docs.expo.dev/technical-specs/expo-updates-0/#manifest-response-body

This allows non-JavaScript assets to load in apps using the expo-updates library.

To get this working in your server, pull the changes from this PR to include the `fileExtension` key in the manifest response on the assets. Then start a new server and make a request.

# Test plan

I got the app in expo-updates-client running, then I added an image to the app's home screen.  Then, I ran the server and saw the image appear after restarting the app.

<img width="564" alt="Screen Shot 2022-04-08 at 12 19 25 PM" src="https://user-images.githubusercontent.com/6455018/162482208-c34ef700-92b3-4ce5-b386-8f8f5326d39b.png">

