### PR TITLE
fix: add metadata and extra fields to manifest to satisfy protocol

### DIFF
--- a/expo-updates-server/__tests__/manifest.test.ts
+++ b/expo-updates-server/__tests__/manifest.test.ts
@@ -118,6 +118,8 @@ test.each([
 
   expect(data.id).toBe('5668cf5b-c7cc-1fc3-da9c-4b6548e9eb9c');
   expect(data.runtimeVersion).toBe('test');
+  expect(data.metadata).toEqual({});
+  expect(data.extra).toEqual({});
 
   const launchAsset = data.launchAsset;
   expect(launchAsset.hash).toBe(launchAssetExpectation.hash);

--- a/expo-updates-server/pages/api/manifest.ts
+++ b/expo-updates-server/pages/api/manifest.ts
@@ -66,6 +66,8 @@ export default async function manifestEndpoint(req: NextApiRequest, res: NextApi
         platform,
         ext: null,
       }),
+      metadata: {},
+      extra: {},
     };
 
     let signature = null;


### PR DESCRIPTION
This fixes (1) from https://github.com/expo/custom-expo-updates-server/issues/12#issuecomment-1334121928.

Investigation into this revealed that the only place that https://github.com/expo/expo/blob/main/packages/expo-manifests/android/src/main/java/expo/modules/manifests/core/Manifest.kt#L229 is used (in this library) is https://github.com/expo/expo/blob/main/packages/expo-updates/android/src/main/java/expo/modules/updates/selectionpolicy/SelectionPolicies.kt#L22, so it would just return true (erroneously).