### PR TITLE
server: re-add protocol version 0 compatibility

### DIFF
--- a/expo-updates-server/__tests__/__snapshots__/manifest.test.ts.snap
+++ b/expo-updates-server/__tests__/__snapshots__/manifest.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`returns latest "android" manifest 1`] = `
+exports[`protocol version "0" returns latest "android" manifest 1`] = `
 Object {
   "expoClient": Object {
     "android": Object {
@@ -49,7 +49,105 @@ Object {
 }
 `;
 
-exports[`returns latest "ios" manifest 1`] = `
+exports[`protocol version "0" returns latest "ios" manifest 1`] = `
+Object {
+  "expoClient": Object {
+    "android": Object {
+      "adaptiveIcon": Object {
+        "backgroundColor": "#FFFFFF",
+        "foregroundImage": "./assets/adaptive-icon.png",
+      },
+      "package": "com.test.expoupdatesclient",
+    },
+    "assetBundlePatterns": Array [
+      "**/*",
+    ],
+    "currentFullName": "@anonymous/expo-updates-client",
+    "icon": "./assets/icon.png",
+    "ios": Object {
+      "bundleIdentifier": "com.test.expo-updates-client",
+      "supportsTablet": true,
+    },
+    "name": "expo-updates-client",
+    "orientation": "portrait",
+    "originalFullName": "@anonymous/expo-updates-client",
+    "owner": "anonymous",
+    "platforms": Array [
+      "ios",
+      "android",
+      "web",
+    ],
+    "runtimeVersion": "1",
+    "sdkVersion": "47.0.0",
+    "slug": "expo-updates-client",
+    "splash": Object {
+      "backgroundColor": "#ffffff",
+      "image": "./assets/splash.png",
+      "resizeMode": "contain",
+    },
+    "updates": Object {
+      "enabled": true,
+      "fallbackToCacheTimeout": 30000,
+      "url": "http://localhost:3000/api/manifest",
+    },
+    "version": "1.0.0",
+    "web": Object {
+      "favicon": "./assets/favicon.png",
+    },
+  },
+}
+`;
+
+exports[`protocol version "1" returns latest "android" manifest 1`] = `
+Object {
+  "expoClient": Object {
+    "android": Object {
+      "adaptiveIcon": Object {
+        "backgroundColor": "#FFFFFF",
+        "foregroundImage": "./assets/adaptive-icon.png",
+      },
+      "package": "com.test.expoupdatesclient",
+    },
+    "assetBundlePatterns": Array [
+      "**/*",
+    ],
+    "currentFullName": "@anonymous/expo-updates-client",
+    "icon": "./assets/icon.png",
+    "ios": Object {
+      "bundleIdentifier": "com.test.expo-updates-client",
+      "supportsTablet": true,
+    },
+    "name": "expo-updates-client",
+    "orientation": "portrait",
+    "originalFullName": "@anonymous/expo-updates-client",
+    "owner": "anonymous",
+    "platforms": Array [
+      "ios",
+      "android",
+      "web",
+    ],
+    "runtimeVersion": "1",
+    "sdkVersion": "47.0.0",
+    "slug": "expo-updates-client",
+    "splash": Object {
+      "backgroundColor": "#ffffff",
+      "image": "./assets/splash.png",
+      "resizeMode": "contain",
+    },
+    "updates": Object {
+      "enabled": true,
+      "fallbackToCacheTimeout": 30000,
+      "url": "http://localhost:3000/api/manifest",
+    },
+    "version": "1.0.0",
+    "web": Object {
+      "favicon": "./assets/favicon.png",
+    },
+  },
+}
+`;
+
+exports[`protocol version "1" returns latest "ios" manifest 1`] = `
 Object {
   "expoClient": Object {
     "android": Object {

--- a/expo-updates-server/__tests__/manifest.test.ts
+++ b/expo-updates-server/__tests__/manifest.test.ts
@@ -31,7 +31,7 @@ afterEach(() => {
   process.env = env;
 });
 
-test('returns 400 with POST request', async () => {
+test('returns 405 with POST request', async () => {
   const { req, res } = createMocks({ method: 'POST' });
 
   await handleManifest(req, res);
@@ -68,72 +68,75 @@ test('returns 404 with unknown runtime version', async () => {
   expect(res._getStatusCode()).toBe(404);
 });
 
-test.each([
-  [
-    'ios',
-    {
-      hash: '4nGjshgRoD62YxnJAnZBWllEzCBrQR2zQ_2ei8glL6s',
-      key: '9d01842d6ee1224f7188971c5d397115',
-      fileExtension: '.bundle',
-      contentType: 'application/javascript',
-      url: `${process.env.HOSTNAME}/api/assets?asset=updates/test/1/bundles/ios-9d01842d6ee1224f7188971c5d397115.js&runtimeVersion=test&platform=ios`,
-    },
-  ],
-  [
-    'android',
-    {
-      hash: 't3kWQ00Lhn5qCGGhNNMxiD_pcTO_4d7I_1zO3S5Me5k',
-      key: '82adadb1fb6e489d04ad95fd79670deb',
-      fileExtension: '.bundle',
-      contentType: 'application/javascript',
-      url: `${process.env.HOSTNAME}/api/assets?asset=updates/test/1/bundles/android-82adadb1fb6e489d04ad95fd79670deb.js&runtimeVersion=test&platform=android`,
-    },
-  ],
-])('returns latest %p manifest', async (platform, launchAssetExpectation) => {
-  process.env.PRIVATE_KEY_PATH = 'updates/test/1/privatekey.pem';
+describe.each([['0'], ['1']])('protocol version %p', (protocolVersion) => {
+  test.each([
+    [
+      'ios',
+      {
+        hash: '4nGjshgRoD62YxnJAnZBWllEzCBrQR2zQ_2ei8glL6s',
+        key: '9d01842d6ee1224f7188971c5d397115',
+        fileExtension: '.bundle',
+        contentType: 'application/javascript',
+        url: `${process.env.HOSTNAME}/api/assets?asset=updates/test/1/bundles/ios-9d01842d6ee1224f7188971c5d397115.js&runtimeVersion=test&platform=ios`,
+      },
+    ],
+    [
+      'android',
+      {
+        hash: 't3kWQ00Lhn5qCGGhNNMxiD_pcTO_4d7I_1zO3S5Me5k',
+        key: '82adadb1fb6e489d04ad95fd79670deb',
+        fileExtension: '.bundle',
+        contentType: 'application/javascript',
+        url: `${process.env.HOSTNAME}/api/assets?asset=updates/test/1/bundles/android-82adadb1fb6e489d04ad95fd79670deb.js&runtimeVersion=test&platform=android`,
+      },
+    ],
+  ])('returns latest %p manifest', async (platform, launchAssetExpectation) => {
+    process.env.PRIVATE_KEY_PATH = 'updates/test/1/privatekey.pem';
 
-  const firstAssetExpectation = {
-    hash: 'JCcs2u_4LMX6zazNmCpvBbYMRQRwS7-UwZpjiGWYgLs',
-    key: '4f1cb2cac2370cd5050681232e8575a8',
-    fileExtension: '.jpg',
-    contentType: 'image/png',
-    url: `${process.env.HOSTNAME}/api/assets?asset=updates/test/1/assets/4f1cb2cac2370cd5050681232e8575a8&runtimeVersion=test&platform=${platform}`,
-  };
-  const { req, res } = createMocks({
-    method: 'GET',
-    headers: {
-      'expo-runtime-version': 'test',
-      'expo-platform': platform,
-      'expo-channel-name': 'main',
-      'expo-expect-signature': 'true',
-    },
+    const firstAssetExpectation = {
+      hash: 'JCcs2u_4LMX6zazNmCpvBbYMRQRwS7-UwZpjiGWYgLs',
+      key: '4f1cb2cac2370cd5050681232e8575a8',
+      fileExtension: '.jpg',
+      contentType: 'image/png',
+      url: `${process.env.HOSTNAME}/api/assets?asset=updates/test/1/assets/4f1cb2cac2370cd5050681232e8575a8&runtimeVersion=test&platform=${platform}`,
+    };
+    const { req, res } = createMocks({
+      method: 'GET',
+      headers: {
+        'expo-protocol-version': protocolVersion,
+        'expo-runtime-version': 'test',
+        'expo-platform': platform,
+        'expo-channel-name': 'main',
+        'expo-expect-signature': 'true',
+      },
+    });
+
+    await handleManifest(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+
+    const { body, headers } = nullthrows(await getManifestPartAsync(res, 'manifest'));
+    const data = JSON.parse(body);
+
+    expect(data.id).toBe('b15ed6d8-f39b-04ad-a248-fa3b95fd7e0e');
+    expect(data.runtimeVersion).toBe('test');
+    expect(data.metadata).toEqual({});
+    expect(data.extra).toMatchSnapshot();
+
+    const launchAsset = data.launchAsset;
+    expect(launchAsset.hash).toBe(launchAssetExpectation.hash);
+    expect(launchAsset.key).toBe(launchAssetExpectation.key);
+    expect(launchAsset.contentType).toBe(launchAssetExpectation.contentType);
+    expect(launchAsset.url).toBe(launchAssetExpectation.url);
+
+    const firstAsset = data.assets[0];
+    expect(firstAsset.hash).toBe(firstAssetExpectation.hash);
+    expect(firstAsset.key).toBe(firstAssetExpectation.key);
+    expect(firstAsset.contentType).toBe(firstAssetExpectation.contentType);
+    expect(firstAsset.url).toBe(firstAssetExpectation.url);
+
+    expect(headers.get('expo-signature')).toBeTruthy();
   });
-
-  await handleManifest(req, res);
-
-  expect(res._getStatusCode()).toBe(200);
-
-  const { body, headers } = nullthrows(await getManifestPartAsync(res, 'manifest'));
-  const data = JSON.parse(body);
-
-  expect(data.id).toBe('b15ed6d8-f39b-04ad-a248-fa3b95fd7e0e');
-  expect(data.runtimeVersion).toBe('test');
-  expect(data.metadata).toEqual({});
-  expect(data.extra).toMatchSnapshot();
-
-  const launchAsset = data.launchAsset;
-  expect(launchAsset.hash).toBe(launchAssetExpectation.hash);
-  expect(launchAsset.key).toBe(launchAssetExpectation.key);
-  expect(launchAsset.contentType).toBe(launchAssetExpectation.contentType);
-  expect(launchAsset.url).toBe(launchAssetExpectation.url);
-
-  const firstAsset = data.assets[0];
-  expect(firstAsset.hash).toBe(firstAssetExpectation.hash);
-  expect(firstAsset.key).toBe(firstAssetExpectation.key);
-  expect(firstAsset.contentType).toBe(firstAssetExpectation.contentType);
-  expect(firstAsset.url).toBe(firstAssetExpectation.url);
-
-  expect(headers.get('expo-signature')).toBeTruthy();
 });
 
 test.each([['ios'], ['android']])('returns rollback %p', async (platform) => {
@@ -142,6 +145,7 @@ test.each([['ios'], ['android']])('returns rollback %p', async (platform) => {
   const { req, res } = createMocks({
     method: 'GET',
     headers: {
+      'expo-protocol-version': '1',
       'expo-runtime-version': 'testrollback',
       'expo-platform': platform,
       'expo-channel-name': 'main',
@@ -162,4 +166,23 @@ test.each([['ios'], ['android']])('returns rollback %p', async (platform) => {
   });
 
   expect(headers.get('expo-signature')).toBeTruthy();
+});
+
+test.each([['ios'], ['android']])('throws for rollback %p for protocol 0', async (platform) => {
+  process.env.PRIVATE_KEY_PATH = 'updates/test/1/privatekey.pem';
+
+  const { req, res } = createMocks({
+    method: 'GET',
+    headers: {
+      'expo-runtime-version': 'testrollback',
+      'expo-platform': platform,
+      'expo-channel-name': 'main',
+      'expo-expect-signature': 'true',
+      'expo-embedded-update-id': '123',
+    },
+  });
+
+  await handleManifest(req, res);
+
+  expect(res._getStatusCode()).toBe(404);
 });


### PR DESCRIPTION
Closes https://github.com/expo/custom-expo-updates-server/issues/28.

This was converted into a version 1 server recently. There are still clients (like iOS master) that only know how to communicate using version 0. Android master can do 0 or 1.

This PR makes this server support 0 or 1.