### PR TITLE
fix: Expo Current Update Id and Update Id check

### DIFF
--- a/expo-updates-server/pages/api/manifest.ts
+++ b/expo-updates-server/pages/api/manifest.ts
@@ -117,9 +117,11 @@ async function putUpdateInResponseAsync(
     runtimeVersion,
   });
 
+  const updateIdHash = convertSHA256HashToUUID(id);
+
   // NoUpdateAvailable directive only supported on protocol version 1
   // for protocol version 0, serve most recent update as normal
-  if (currentUpdateId === id && protocolVersion === 1) {
+  if (currentUpdateId === updateIdHash && protocolVersion === 1) {
     throw new NoUpdateAvailableError();
   }
 
@@ -129,7 +131,7 @@ async function putUpdateInResponseAsync(
   });
   const platformSpecificMetadata = metadataJson.fileMetadata[platform];
   const manifest = {
-    id: convertSHA256HashToUUID(id),
+    id: updateIdHash,
     createdAt,
     runtimeVersion,
     assets: await Promise.all(


### PR DESCRIPTION
In the code we are doing equality check on `currentUpdateId` & `id` in line #122. Which fails everytime because we are passing a hash in the `manifest` API request from the android mobile application. Due to this we are always responding with the manifest to the mobile application.

This PR will fix this issue.

<img width="664" alt="Screenshot 2024-02-02 at 11 52 46 AM" src="https://github.com/expo/custom-expo-updates-server/assets/24573714/02d395b8-e082-4081-be2b-9ee4124da95c">
