### PR TITLE
fix wrong id check

### DIFF
--- a/expo-updates-server/pages/api/manifest.ts
+++ b/expo-updates-server/pages/api/manifest.ts
@@ -119,7 +119,7 @@ async function putUpdateInResponseAsync(
 
   // NoUpdateAvailable directive only supported on protocol version 1
   // for protocol version 0, serve most recent update as normal
-  if (currentUpdateId === id && protocolVersion === 1) {
+  if (currentUpdateId === convertSHA256HashToUUID(id) && protocolVersion === 1) {
     throw new NoUpdateAvailableError();
   }
 

--- a/node_modules/.yarn-integrity
+++ b/node_modules/.yarn-integrity
@@ -1,0 +1,19 @@
+{
+  "systemParams": "darwin-arm64-115",
+  "modulesFolders": [],
+  "flags": [],
+  "linkedModules": [
+    "@warp/biz-interfaces",
+    "@warp/biz-warehouse",
+    "@warp/events",
+    "@warp/handlers",
+    "@warp/module-manager",
+    "@warp/types",
+    "@warp/utils",
+    "warp"
+  ],
+  "topLevelPatterns": [],
+  "lockfileEntries": {},
+  "files": [],
+  "artifacts": {}
+}


### PR DESCRIPTION
The id get from header['expo-current-update-id'] is ulid, so we need to convert SHA265 hash to ulid before comparing.
Thank you for your project.