### PR TITLE
Added .trim() to resolve some issues others and I were having.

### DIFF
--- a/expo-updates-server/common/helpers.ts
+++ b/expo-updates-server/common/helpers.ts
@@ -155,7 +155,7 @@ export async function getExpoConfigAsync({
   try {
     const expoConfigPath = `${updateBundlePath}/expoConfig.json`;
     const expoConfigBuffer = await fs.readFile(path.resolve(expoConfigPath), null);
-    const expoConfigJson = JSON.parse(expoConfigBuffer.toString('utf-8'));
+    const expoConfigJson = JSON.parse(expoConfigBuffer.toString('utf-8').trim());
     return expoConfigJson;
   } catch (error) {
     throw new Error(


### PR DESCRIPTION
Fix: In a few instances of json formatting for others and myself the "getExpoConfigAsync()" method was inconsistent in its parsing, throwing an error stating unknown characters were being added to the json file though we could not find said characters. Not a big deal, just figured it would be worth adding in case others have the same issue in the future.

