### PR TITLE
Fix runtime version that update files are copied to in package.json

### DIFF
--- a/expo-updates-server/package.json
+++ b/expo-updates-server/package.json
@@ -8,8 +8,8 @@
     "start": "PRIVATE_KEY_PATH=code-signing-keys/private-key.pem next start",
     "lint": "eslint common pages",
     "test": "jest",
-    "expo-publish": "./scripts/publish.sh -d 1/$(date +%s)",
-    "expo-publish-rollback": "mktouch() { mkdir -p $(dirname $1) && touch $1; }; cd ../expo-updates-server && mktouch updates/1/$(date +%s)/rollback",
+    "expo-publish": "./scripts/publish.sh -d 2/$(date +%s)",
+    "expo-publish-rollback": "mktouch() { mkdir -p $(dirname $1) && touch $1; }; cd ../expo-updates-server && mktouch updates/2/$(date +%s)/rollback",
     "expo-publish-test": "./scripts/publish.sh -d test/$(date +%s)"
   },
   "dependencies": {

--- a/expo-updates-server/scripts/publish.sh
+++ b/expo-updates-server/scripts/publish.sh
@@ -9,6 +9,7 @@ cd ../expo-updates-client
 npx expo export
 cd ../expo-updates-server
 rm -rf updates/$directory/
+mkdir -p "updates/$directory"
 cp -r ../expo-updates-client/dist/ updates/$directory
 
 node ./scripts/exportClientExpoConfig.js > updates/$directory/expoConfig.json


### PR DESCRIPTION
Simple PR fix:
- The runtime version is set to `2` throughout the client code. However, when you run `yarn expo-publish`, it copies the export to `updates/1` instead of `updates/2`. As a result, when the manifest endpoint is called, it doesn't detect the new update.
- Update the publish script to create the `updates/$directory` folder ahead of time to prevent errors like `./scripts/publish.sh: line 14: updates/2/1762392374/expoConfig.json: No such file or directory`

Debugged live with Cedric ;)

<!--
Important note: This repo exists to provide a basic demonstration of how the expo-updates protocol can be translated to code. It is not designed to be complete, stable, or performant enough to use as a full-fledged backend for expo-updates. Any pull requests that add new features will likely be closed; instead, feel free to fork the repository to add new features.

If submitting a pull request for a bug fix, please describe the bug and how this PR fixes it.
-->
